### PR TITLE
Reapply "fix: Remove CNAME so grodin.github.io works again"

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-onemanbaboon.xyz


### PR DESCRIPTION
This reverts commit c5723ee2eb9e2282d2ac9c68513e25e1a9510898.
